### PR TITLE
Addrepos

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,40 @@
-hash: 2598f35c31c4465ab02c25a09149975b604e8ab3a8341064220a922f2b1946d6
-updated: 2017-04-13T16:19:16.597110082-06:00
+hash: 72fe8d81ba5e9214188e9af0fb00f6c97d5860aa284920a7cb87d30d26513195
+updated: 2017-04-18T16:25:05.790707141-06:00
 imports:
 - name: github.com/blang/semver
   version: 31b736133b98f26d5e078ec9eb591666edfd091f
+- name: github.com/ericchiang/k8s
+  version: bd3351b0ceb817083a3226c152e3a2c9bb2849c9
+  subpackages:
+  - api/v1
+  - apis/meta/v1
+  - api/unversioned
+  - apis/apps/v1alpha1
+  - apis/apps/v1beta1
+  - apis/authentication/v1
+  - apis/authentication/v1beta1
+  - apis/authorization/v1
+  - apis/authorization/v1beta1
+  - apis/autoscaling/v1
+  - apis/autoscaling/v2alpha1
+  - apis/batch/v1
+  - apis/batch/v2alpha1
+  - apis/certificates/v1alpha1
+  - apis/certificates/v1beta1
+  - apis/extensions/v1beta1
+  - apis/imagepolicy/v1alpha1
+  - apis/policy/v1alpha1
+  - apis/policy/v1beta1
+  - apis/rbac/v1alpha1
+  - apis/rbac/v1beta1
+  - apis/settings/v1alpha1
+  - apis/storage/v1
+  - apis/storage/v1beta1
+  - runtime
+  - watch/versioned
+  - api/resource
+  - runtime/schema
+  - util/intstr
 - name: github.com/facebookgo/symwalk
   version: 42004b9f322246749dd73ad71008b1f3160c0052
 - name: github.com/ghodss/yaml
@@ -11,11 +43,11 @@ imports:
   version: bea32b9cd2d6f55753d94a28e959b13f0244797a
   subpackages:
   - compiler
-  - match
   - syntax
+  - match
   - syntax/ast
-  - syntax/lexer
   - util/runes
+  - syntax/lexer
   - util/strings
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
@@ -25,6 +57,10 @@ imports:
   - proto
   - ptypes/any
   - ptypes/timestamp
+- name: github.com/gorilla/context
+  version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
+- name: github.com/gorilla/mux
+  version: 392c28fe23e1c45ddba891b0320b3b5df220beea
 - name: github.com/Masterminds/semver
   version: 3f0ab6d4ab4bed1c61caf056b63a6e62190c7801
 - name: github.com/naoina/go-stringutil
@@ -36,36 +72,36 @@ imports:
 - name: golang.org/x/net
   version: e90d6d0afc4c315a0d87a568ae68577cc15149a0
   subpackages:
-  - context
   - http2
+  - context
   - http2/hpack
-  - internal/timeseries
   - lex/httplex
   - trace
+  - internal/timeseries
 - name: google.golang.org/grpc
   version: b7f1379d3cbbbeb2ca3405852012e237aa05459e
   subpackages:
-  - codes
   - credentials
+  - metadata
+  - codes
   - grpclog
   - internal
-  - metadata
   - naming
-  - peer
   - transport
+  - peer
 - name: gopkg.in/yaml.v2
   version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 - name: k8s.io/helm
   version: 32562a3040bb5ca690339b9840b6f60f8ce25da4
   subpackages:
-  - pkg/chartutil
   - pkg/helm
-  - pkg/ignore
+  - pkg/chartutil
   - pkg/proto/hapi/chart
   - pkg/proto/hapi/release
   - pkg/proto/hapi/services
-  - pkg/proto/hapi/version
   - pkg/version
+  - pkg/ignore
+  - pkg/proto/hapi/version
 - name: k8s.io/kubernetes
   version: ea8f6637b639246faa14a8d5c6f864100fcb77a9
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,3 +4,10 @@ import:
   version: ~2.3.1
   subpackages:
   - pkg/helm
+- package: github.com/gorilla/mux
+  version: ^1.3.0
+- package: github.com/ericchiang/k8s
+  version: ^0.3.0
+  subpackages:
+  - api/v1
+  - apis/meta/v1

--- a/handlers.go
+++ b/handlers.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func AddHelmRepoHandler(w http.ResponseWriter, r *http.Request) {
+	decoder := json.NewDecoder(r.Body)
+	var newRepo HelmRepo
+	err := decoder.Decode(&newRepo)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+	defer r.Body.Close()
+
+	err = SaveHelmRepo(K8sClient, newRepo)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	} else {
+		err = json.NewEncoder(w).Encode(newRepo)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}
+
+}
+
+func HelmRepoHandler(w http.ResponseWriter, r *http.Request) {
+
+	switch r.Method {
+	case "POST":
+		AddHelmRepoHandler(w, r)
+		return
+	default:
+		repos, err := GetHelmRepos(K8sClient)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+		err = json.NewEncoder(w).Encode(repos)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}
+
+}

--- a/helm.go
+++ b/helm.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/ericchiang/k8s"
+	"github.com/ericchiang/k8s/api/v1"
+	metav1 "github.com/ericchiang/k8s/apis/meta/v1"
+	"k8s.io/helm/pkg/helm"
+)
+
+type HelmClient struct {
+	c *helm.Client
+}
+
+func NewHelmClient(host string) *HelmClient {
+	return &HelmClient{
+		c: helm.NewClient(helm.Host(host)),
+	}
+}
+
+func (c HelmClient) listReleases(w http.ResponseWriter, r *http.Request) {
+	releases, err := c.c.ListReleases()
+	if err != nil {
+		log.Printf("failed to list releases: %v", err)
+		return
+	}
+	for _, r := range releases.GetReleases() {
+		io.WriteString(w, r.Name)
+	}
+}
+
+type HelmRepo struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+func GetHelmRepos(client *k8s.Client) ([]HelmRepo, error) {
+	var repos []HelmRepo
+	configMap, err := client.CoreV1().GetConfigMap(context.Background(), HELMUIConfigMap, "default")
+	if err != nil {
+		return repos, err
+	}
+
+	for k, v := range configMap.Data {
+		repo := HelmRepo{
+			Name: k,
+			URL:  v,
+		}
+		repos = append(repos, repo)
+	}
+
+	return repos, nil
+}
+
+func SaveHelmRepo(client *k8s.Client, r HelmRepo) error {
+	// need to deal with the namespacing at some point
+	namespace := "default"
+	ctx := context.Background()
+	// try to get teh config map and create it if it does not
+	configMap, err := client.CoreV1().GetConfigMap(ctx, HELMUIConfigMap, namespace)
+	if err != nil {
+
+		if !strings.Contains(err.Error(), fmt.Sprintf(`configmaps "%s" not found`, HELMUIConfigMap)) {
+			return err
+		}
+
+		cfgmap := &v1.ConfigMap{
+			Metadata: &metav1.ObjectMeta{
+				Name:      &HELMUIConfigMap,
+				Namespace: &namespace,
+			},
+		}
+
+		configMap, err = client.CoreV1().CreateConfigMap(ctx, cfgmap)
+		if err != nil {
+			return err
+		}
+	}
+
+	// dont save the repo if one exists by that name already
+	if val, ok := configMap.Data[r.Name]; ok {
+		return fmt.Errorf("A helm repo with the name '%s' is already in the system pointing to: %s", r.Name, val)
+	}
+
+	// if this config map is brand new then the data map needs to be initalized
+	if configMap.Data == nil {
+		configMap.Data = map[string]string{}
+	}
+	// now save the new repo url
+	configMap.Data[r.Name] = r.URL
+
+	_, err = client.CoreV1().UpdateConfigMap(ctx, configMap)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -1,156 +1,19 @@
 package main
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/ericchiang/k8s"
-	"github.com/ericchiang/k8s/api/v1"
 	"github.com/gorilla/mux"
-
-	metav1 "github.com/ericchiang/k8s/apis/meta/v1"
-	"k8s.io/helm/pkg/helm"
 )
 
 var (
 	K8sClient       *k8s.Client
 	HELMUIConfigMap = "helmui"
 )
-
-type HelmClient struct {
-	c *helm.Client
-}
-
-func NewHelmClient(host string) *HelmClient {
-	return &HelmClient{
-		c: helm.NewClient(helm.Host(host)),
-	}
-}
-
-func (c HelmClient) listReleases(w http.ResponseWriter, r *http.Request) {
-	releases, err := c.c.ListReleases()
-	if err != nil {
-		log.Printf("failed to list releases: %v", err)
-		return
-	}
-	for _, r := range releases.GetReleases() {
-		io.WriteString(w, r.Name)
-	}
-}
-
-type HelmRepo struct {
-	Name string `json:"name"`
-	URL  string `json:"url"`
-}
-
-func GetHelmRepos(client *k8s.Client) ([]HelmRepo, error) {
-	var repos []HelmRepo
-	configMap, err := client.CoreV1().GetConfigMap(context.Background(), HELMUIConfigMap, "default")
-	if err != nil {
-		return repos, err
-	}
-
-	for k, v := range configMap.Data {
-		repo := HelmRepo{
-			Name: k,
-			URL:  v,
-		}
-		repos = append(repos, repo)
-	}
-
-	return repos, nil
-}
-
-func SaveHelmRepo(client *k8s.Client, r HelmRepo) error {
-	// need to deal with the namespacing at some point
-	namespace := "default"
-	ctx := context.Background()
-	// try to get teh config map and create it if it does not
-	configMap, err := client.CoreV1().GetConfigMap(ctx, HELMUIConfigMap, namespace)
-	if err != nil {
-
-		if !strings.Contains(err.Error(), fmt.Sprintf(`configmaps "%s" not found`, HELMUIConfigMap)) {
-			return err
-		}
-
-		cfgmap := &v1.ConfigMap{
-			Metadata: &metav1.ObjectMeta{
-				Name:      &HELMUIConfigMap,
-				Namespace: &namespace,
-			},
-		}
-
-		configMap, err = client.CoreV1().CreateConfigMap(ctx, cfgmap)
-		if err != nil {
-			return err
-		}
-	}
-
-	// dont save the repo if one exists by that name already
-	if val, ok := configMap.Data[r.Name]; ok {
-		return fmt.Errorf("A helm repo with the name '%s' is already in the system pointing to: %s", r.Name, val)
-	}
-
-	// if this config map is brand new then the data map needs to be initalized
-	if configMap.Data == nil {
-		configMap.Data = map[string]string{}
-	}
-	// now save the new repo url
-	configMap.Data[r.Name] = r.URL
-
-	_, err = client.CoreV1().UpdateConfigMap(ctx, configMap)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func AddHelmRepoHandler(w http.ResponseWriter, r *http.Request) {
-	decoder := json.NewDecoder(r.Body)
-	var newRepo HelmRepo
-	err := decoder.Decode(&newRepo)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-	}
-	defer r.Body.Close()
-
-	err = SaveHelmRepo(K8sClient, newRepo)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-	} else {
-		err = json.NewEncoder(w).Encode(newRepo)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-	}
-
-}
-
-func HelmRepoHandler(w http.ResponseWriter, r *http.Request) {
-
-	switch r.Method {
-	case "POST":
-		AddHelmRepoHandler(w, r)
-		return
-	default:
-		repos, err := GetHelmRepos(K8sClient)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		err = json.NewEncoder(w).Encode(repos)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-	}
-
-}
 
 func main() {
 	helmClient := NewHelmClient(os.Getenv("TILLER_HOST"))

--- a/main.go
+++ b/main.go
@@ -125,11 +125,10 @@ func AddHelmRepoHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	} else {
-		payload, err := json.MarshalIndent(newRepo, "", "  ")
+		err = json.NewEncoder(w).Encode(newRepo)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-		io.WriteString(w, string(payload))
 	}
 
 }
@@ -145,11 +144,10 @@ func HelmRepoHandler(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-		payload, err := json.MarshalIndent(repos, "", "  ")
+		err = json.NewEncoder(w).Encode(repos)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-		io.WriteString(w, string(payload))
 	}
 
 }

--- a/main.go
+++ b/main.go
@@ -45,8 +45,8 @@ func (c HelmClient) listReleases(w http.ResponseWriter, r *http.Request) {
 }
 
 type HelmRepo struct {
-	Name string
-	URL  string
+	Name string `json:"name"`
+	URL  string `json:"url"`
 }
 
 func GetHelmRepos(client *k8s.Client) ([]HelmRepo, error) {


### PR DESCRIPTION
This got a tad bit out of scope really.

With this PR you can POST a new helm repo and GET the list of stored helm repos. For now the list of repos is being stored in a Config Map.

The endpoint that allows you to achieve this is /repo

To test:

    deploy the helmui chart
    POST '{"name": "your-chart-repo-name","url":"http://your/chart/repo"}' to /repo
    GET /repo and ensure the helm repo you POSTed in step 2 is returned
