### PR TITLE
Chart releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ web/src/app/*.js
 web/src/app/*.map
 web/src/main.js
 web/src/main.js.map
+web/src/app/config/*.js
+web/src/app/config/*.map
 web/node_modules
 web/jspm_packages
 web/bower_components

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,6 +7,7 @@ import:
   - pkg/helm/helmpath
   - pkg/repo
   - pkg/downloader
+  - pkg/release
 - package: github.com/gorilla/mux
   version: ^1.3.0
 - package: github.com/ericchiang/k8s

--- a/web/src/app/app.module.ts
+++ b/web/src/app/app.module.ts
@@ -10,6 +10,7 @@ import { ChartReposComponent }   from './chart-repos.component';
 import { ChartRepoDetailComponent } from './chart-repo-detail.component';
 
 import { ReleasesComponent }      from './releases.component';
+import { ChartReleasesComponent } from './chart-releases.component'
 
 import { ReleaseService }          from './release.service';
 import { ChartRepoService }          from './chart-repo.service';
@@ -26,6 +27,7 @@ import { ChartRepoService }          from './chart-repo.service';
     ChartReposComponent,
     ReleasesComponent,
     ChartRepoDetailComponent,
+    ChartReleasesComponent,
   ],
   providers: [ 
     ReleaseService,

--- a/web/src/app/chart-releases.component.css
+++ b/web/src/app/chart-releases.component.css
@@ -1,7 +1,4 @@
-.selected {
-  background-color: #CFD8DC !important;
-  color: white;
-}
+
 .heroes {
   margin: 0 0 2em 0;
   list-style-type: none;
@@ -12,7 +9,7 @@
   cursor: pointer;
   position: relative;
   left: 0;
-  background-color: #EEE;
+  background-color: antiquewhite;
   margin: .5em;
   padding: .3em 0;
   height: auto;
@@ -60,6 +57,7 @@ button.install {
   margin-right: .8em;
   background-color: gray !important;
   color:white;
+  height: auto;
 }
 
 .install:hover {
@@ -69,4 +67,9 @@ button.install {
 
 span.badge {
   float: left;
+}
+
+div.chart-releases {
+  height: auto !important;
+  overflow: auto;
 }

--- a/web/src/app/chart-releases.component.css
+++ b/web/src/app/chart-releases.component.css
@@ -1,44 +1,26 @@
 
-.heroes {
+.releases {
   margin: 0 0 2em 0;
   list-style-type: none;
   padding: 0;
   width: 60em;
 }
-.heroes li {
+.releases li {
   cursor: pointer;
   position: relative;
   left: 0;
-  background-color: antiquewhite;
   margin: .5em;
   padding: .3em 0;
   height: auto;
+  width: 75%;
   border-radius: 4px;
+  border-bottom: 1px dotted gray;
+
 }
 
-.heroes .text {
+.releases .text {
   position: relative;
   top: -3px;
-}
-.heroes .badge {
-  display: inline-block;
-  font-size: small;
-  color: white;
-  padding: 0.8em 0.7em 0 0.7em;
-  background-color: #607D8B;
-  line-height: 1em;
-  position: relative;
-  left: -1px;
-  top: -4px;
-  height: 1.8em;
-  margin-right: .8em;
-  border-radius: 4px 0 0 4px;
-  width: 10em;
-}
-
-.heroes .badge img {
-  width: 200px;
-
 }
 
 button {

--- a/web/src/app/chart-releases.component.html
+++ b/web/src/app/chart-releases.component.html
@@ -3,7 +3,7 @@
       (click)="install()">install</button>
   <div *ngIf="releases">
     <h4>Releases:</h4>
-    <ul class="heroes">
+    <ul class="releases">
     <li *ngFor="let release of releases">
       <span>{{release.name}}</span>
       {{release.namespace}}

--- a/web/src/app/chart-releases.component.html
+++ b/web/src/app/chart-releases.component.html
@@ -1,0 +1,14 @@
+<div class="chart-releases">
+  <button class="install"
+      (click)="install()">install</button>
+  <div *ngIf="releases">
+    <h4>Releases:</h4>
+    <ul class="heroes">
+    <li *ngFor="let release of releases">
+      <span>{{release.name}}</span>
+      {{release.namespace}}
+      {{release.version}}
+    </li>
+    </ul>
+  </div>
+</div>

--- a/web/src/app/chart-releases.component.ts
+++ b/web/src/app/chart-releases.component.ts
@@ -1,0 +1,57 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { Router }            from '@angular/router';
+
+import { Observable }        from 'rxjs/Observable';
+import { Subject }           from 'rxjs/Subject';
+
+// Observable class extensions
+import 'rxjs/add/observable/of';
+
+import { ChartRepoService } from './chart-repo.service';
+import { ReleaseService } from './release.service';
+
+import { Release } from './release';
+import { Chart } from './chart';
+
+@Component({
+  selector: 'chart-releases',
+  templateUrl: './chart-releases.component.html',
+  styleUrls: [ './chart-releases.component.css' ],
+  providers: [ReleaseService]
+})
+export class ChartReleasesComponent implements OnInit {
+  @Input() chartName: string;
+  @Input() repoName: string;
+
+  releases: Release[];
+
+  constructor(
+    private releaseService: ReleaseService,
+    private chartRepoService: ChartRepoService,
+    private router: Router) {}
+
+  getChartReleases(chartName: string): void {
+    this.releaseService.getChartReleases(chartName).then(releases => this.releases = releases);
+  }
+
+  ngOnInit(): void {
+    this.getChartReleases(this.chartName);
+  }
+
+  install(): void {
+    this.chartRepoService.install(this.chartName, this.repoName)
+      .then(release => {
+        if (this.releases) { 
+          this.releases.push(release);
+        } else {
+            this.releases = [release];
+        }
+        
+      });
+  }
+
+//   gotoDetail(hero: Hero): void {
+//     let link = ['/detail', hero.id];
+//     this.router.navigate(link);
+//   }
+}

--- a/web/src/app/chart-repo-detail.component.css
+++ b/web/src/app/chart-repo-detail.component.css
@@ -39,8 +39,8 @@
   width: 10em;
 }
 
-.heroes .badge img {
-  width: 200px;
+.heroes img {
+  max-width: 200px;
 
 }
 

--- a/web/src/app/chart-repo-detail.component.html
+++ b/web/src/app/chart-repo-detail.component.html
@@ -5,8 +5,7 @@
     <span class="badge">{{chart.name }}</span>
     <span><img src="{{chart.icon}}" /></span>
     <span>{{ chart.description }} </span>
-    <button class="install"
-      (click)="install(chart)">install</button>
+    <chart-releases [repoName]="repo" [chartName]="chart.name"></chart-releases>
   </li>
   </ul>
 

--- a/web/src/app/chart-repo-detail.component.ts
+++ b/web/src/app/chart-repo-detail.component.ts
@@ -33,10 +33,6 @@ export class ChartRepoDetailComponent implements OnInit {
       this.repo = this.route.snapshot.params['name'];
     }
 
-    install(chart: Chart): void {
-      this.chartRepoService.install(chart.name, this.repo);
-    }
-
     goBack(): void {
       this.location.back();
     }

--- a/web/src/app/chart-repo.service.ts
+++ b/web/src/app/chart-repo.service.ts
@@ -11,7 +11,6 @@ import { Release } from './release';
 export class ChartRepoService {
   private reposUrl = 'http://146.148.44.109/repos';  // URL to web api
 
-
   constructor(private http: Http) { }
 
   getRepos(): Promise<ChartRepo[]> {

--- a/web/src/app/release.service.ts
+++ b/web/src/app/release.service.ts
@@ -7,12 +7,19 @@ import { Release } from './release';
 
 @Injectable()
 export class ReleaseService {
-  private reposUrl = 'http://146.148.44.109/releases';  // URL to web api
+  private releasesUrl = 'http://146.148.44.109/releases';  // URL to web api
 
   constructor(private http: Http) { }
 
   getReleases(): Promise<Release[]> {
-    return this.http.get(this.reposUrl)
+    return this.http.get(this.releasesUrl)
+               .toPromise()
+               .then(response => response.json() as Release[])
+               .catch(this.handleError);
+  }
+
+  getChartReleases(name: string): Promise<Release[]> {
+    return this.http.get(this.releasesUrl+"?chart="+name)
                .toPromise()
                .then(response => response.json() as Release[])
                .catch(this.handleError);

--- a/web/src/app/release.ts
+++ b/web/src/app/release.ts
@@ -1,5 +1,16 @@
+export class Metadata {
+  version: string;
+  name: string;
+  description: string;
+}
+
+export class Chart {
+  metadata: Metadata;
+}
+
 export class Release {
   name: string;
   namespace: string;
   version: number;
+  chart: Chart;
 }


### PR DESCRIPTION
This change adds a list of releases of a chart beneath the `/chart-repos/detail/repo_name` view.

When a user clicks the `install` button for a chart the new release should show up in this list.